### PR TITLE
Add capital holder sync API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,24 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# --- secrets (managed by ID Agents Control Center) ---
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template
+*.pem
+*.key
+*.p12
+*.pfx
+*.keystore
+id_rsa
+id_ed25519
+*.secret
+secrets.json
+service-account*.json
+gha-creds-*.json
+.netrc
+.pgpass
+# --- end secrets ---

--- a/.gitignore
+++ b/.gitignore
@@ -23,24 +23,3 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-# --- secrets (managed by ID Agents Control Center) ---
-.env
-.env.*
-!.env.example
-!.env.sample
-!.env.template
-*.pem
-*.key
-*.p12
-*.pfx
-*.keystore
-id_rsa
-id_ed25519
-*.secret
-secrets.json
-service-account*.json
-gha-creds-*.json
-.netrc
-.pgpass
-# --- end secrets ---

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ Deploys to Vercel from `main`, served at `research.bittrees.org`. Set the enviro
 variables above in the Vercel project; connect an Upstash KV store for the roles/rooms
 registry and cross-device messenger sync.
 
+### Read-only release gate
+
+Use the release gate before promotion, and again after any rollback. It never writes to
+production; it only captures a baseline snapshot, validates a canary URL, and compares the
+current surface back to the saved baseline.
+
+```bash
+yarn release:gate --mode baseline
+yarn release:gate --mode canary --base-url https://<preview-host> --baseline output/release-gates/<baseline-run>/run.json
+yarn release:gate --mode rollback-check --baseline output/release-gates/<baseline-run>/run.json
+```
+
+What it checks:
+
+- SPA routes stay reachable (`/`, `/research`, `/forum`, `/chat`, `/membership`, `/bnote`,
+  `/bit`, `/contribute`, `/admin`)
+- `/api/community`, `/api/rooms`, `/api/usersync`, and the malformed-input `/api/gate`
+  contract stay healthy
+- Rollback verification compares status and structural response signatures to the saved
+  baseline instead of trying to mutate live state
+
+Each run writes `run.json` and `report.md` under `output/release-gates/`.
+
 ---
 
 *Informational only — not investment, legal, or tax advice, and not an offer to sell any

--- a/api/capital-sync.js
+++ b/api/capital-sync.js
@@ -1,0 +1,309 @@
+export const HOLDERS_KEY = "bittrees:capital:holders";
+export const HOLDERS_SYNC_KEY = "bittrees:capital:holdersync";
+export const OVERVIEW_SUPPLY_KEY = "bittrees:capital:overview-supply";
+export const DEFAULT_CONTRACTS = {
+  bnote: "0xf1AAfFc982B5F553a730a9eC134715a547f1fe80",
+  bit: "0x57A447E4d5e18A9423408C365963A73F08B9d18C",
+};
+
+const PAGE_LIMIT = 1000;
+const RESUME_WINDOW_MS = 10 * 60 * 1000;
+
+function isAddress(value) {
+  return /^0x[a-fA-F0-9]{40}$/.test(String(value || ""));
+}
+
+function normalizeAddress(value) {
+  return String(value || "").toLowerCase();
+}
+
+function getAlchemyUrl() {
+  const direct = process.env.ALCHEMY_URL || process.env.ALCHEMY_MAINNET_URL;
+  if (direct) return direct;
+  if (process.env.ALCHEMY_API_KEY) {
+    return `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
+  }
+  return "";
+}
+
+function getKvConfig() {
+  return {
+    url: process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN,
+  };
+}
+
+async function kvCommand(cmd) {
+  const { url, token } = getKvConfig();
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify(cmd),
+  });
+  if (!r.ok) throw new Error(`KV HTTP ${r.status}`);
+  return r.json();
+}
+
+async function readJson(key, fallback) {
+  const { url, token } = getKvConfig();
+  if (!url || !token) return fallback;
+  try {
+    const j = await kvCommand(["GET", key]);
+    return j?.result ? JSON.parse(j.result) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJson(key, value) {
+  const { url, token } = getKvConfig();
+  if (!url || !token) return;
+  await kvCommand(["SET", key, JSON.stringify(value)]);
+}
+
+function emptyState() {
+  return {
+    holders: {},
+    checkpoint: {
+      fromBlock: "0x0",
+      pageKey: null,
+      pageKeyUpdatedAt: 0,
+      lastBlock: 0,
+      updatedAt: 0,
+    },
+    updatedAt: 0,
+  };
+}
+
+function asHexBlock(value) {
+  if (value === "latest" || value === "pending" || value === "earliest") return value;
+  if (typeof value === "string" && value.startsWith("0x")) return value;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return "0x0";
+  return `0x${Math.trunc(n).toString(16)}`;
+}
+
+function toBlockNumber(value) {
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.startsWith("0x")) return Number.parseInt(value, 16);
+  return Number(value || 0);
+}
+
+function applyTransfer(state, transfer) {
+  const from = normalizeAddress(transfer.from);
+  const to = normalizeAddress(transfer.to);
+  const rawValue = Number(transfer.value ?? transfer.rawContract?.value ?? 0);
+  const amount = Number.isFinite(rawValue) ? rawValue : 0;
+
+  if (from && isAddress(from)) {
+    const next = Math.max(0, Number(state.holders[from] || 0) - amount);
+    if (next > 0) state.holders[from] = next;
+    else delete state.holders[from];
+  }
+  if (to && isAddress(to)) {
+    state.holders[to] = Number(state.holders[to] || 0) + amount;
+  }
+
+  const blockNumber = toBlockNumber(transfer.blockNum ?? transfer.blockNumber ?? 0);
+  if (Number.isFinite(blockNumber) && blockNumber > (state.checkpoint.lastBlock || 0)) {
+    state.checkpoint.lastBlock = blockNumber;
+  }
+}
+
+function mergeTransfers(state, transfers) {
+  for (const transfer of transfers || []) {
+    applyTransfer(state, transfer);
+  }
+  return state;
+}
+
+function makeRequestParams({ contractAddress, fromBlock, toBlock, pageKey }) {
+  const params = {
+    fromBlock: asHexBlock(fromBlock),
+    toBlock: asHexBlock(toBlock),
+    contractAddresses: [contractAddress],
+    category: ["erc20", "erc721", "erc1155", "external", "internal"],
+    excludeZeroValue: false,
+    maxCount: `0x${PAGE_LIMIT.toString(16)}`,
+    withMetadata: false,
+  };
+  if (pageKey) params.pageKey = pageKey;
+  return params;
+}
+
+async function fetchTransfers({ contractAddress, fromBlock, toBlock, pageKey }) {
+  const alchemyUrl = getAlchemyUrl();
+  if (!alchemyUrl) throw new Error("alchemy not configured");
+  const r = await fetch(alchemyUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "capital-holder-sync",
+      method: "alchemy_getAssetTransfers",
+      params: [makeRequestParams({ contractAddress, fromBlock, toBlock, pageKey })],
+    }),
+  });
+  if (!r.ok) throw new Error(`Alchemy HTTP ${r.status}`);
+  const j = await r.json();
+  if (j?.error) throw new Error(j.error.message || "alchemy error");
+  return j?.result || { transfers: [], pageKey: null };
+}
+
+function nextCheckpoint(prev, result, sourceToBlock) {
+  const next = {
+    ...prev,
+    updatedAt: Date.now(),
+    lastBlock: Math.max(prev.lastBlock || 0, result.lastBlock || 0),
+  };
+  if (result.pageKey) {
+    next.pageKey = result.pageKey;
+    next.pageKeyUpdatedAt = Date.now();
+    next.fromBlock = prev.fromBlock || "0x0";
+    next.toBlock = sourceToBlock;
+    return next;
+  }
+  next.pageKey = null;
+  next.pageKeyUpdatedAt = 0;
+  next.fromBlock = asHexBlock((next.lastBlock || 0) + 1);
+  next.toBlock = sourceToBlock;
+  return next;
+}
+
+function shouldResumePageKey(checkpoint) {
+  if (!checkpoint?.pageKey) return false;
+  return Date.now() - Number(checkpoint.pageKeyUpdatedAt || 0) <= RESUME_WINDOW_MS;
+}
+
+async function loadSyncState(fromBlock) {
+  const finalized = hydrateHolderState(await readJson(HOLDERS_KEY, null));
+  const checkpointed = hydrateHolderState(await readJson(HOLDERS_SYNC_KEY, null));
+
+  if (shouldResumePageKey(checkpointed.checkpoint)) {
+    return {
+      state: checkpointed,
+      cursor: {
+        fromBlock: checkpointed.checkpoint.fromBlock || fromBlock || "0x0",
+        pageKey: checkpointed.checkpoint.pageKey,
+      },
+    };
+  }
+
+  const resumedFromBlock = fromBlock
+    ?? finalized.checkpoint.fromBlock
+    ?? asHexBlock((finalized.checkpoint.lastBlock || 0) + 1);
+
+  return {
+    state: finalized,
+    cursor: {
+      fromBlock: resumedFromBlock,
+      pageKey: null,
+    },
+  };
+}
+
+export function hydrateHolderState(raw) {
+  const base = emptyState();
+  if (!raw || typeof raw !== "object") return base;
+  return {
+    holders: raw.holders && typeof raw.holders === "object" ? raw.holders : {},
+    checkpoint: raw.checkpoint && typeof raw.checkpoint === "object" ? { ...base.checkpoint, ...raw.checkpoint } : base.checkpoint,
+    updatedAt: Number(raw.updatedAt || 0),
+  };
+}
+
+export function buildHolderSnapshot(state) {
+  return {
+    holders: state.holders,
+    checkpoint: state.checkpoint,
+    updatedAt: state.updatedAt,
+    holderCount: Object.keys(state.holders).length,
+  };
+}
+
+export async function syncHolders({ contractAddress, fromBlock, toBlock } = {}) {
+  const target = contractAddress || DEFAULT_CONTRACTS.bnote;
+  const resolvedToBlock = toBlock ?? "latest";
+  const loaded = await loadSyncState(fromBlock);
+  const state = loaded.state;
+  let cursor = loaded.cursor;
+  let fetched = 0;
+  let latestBlock = state.checkpoint.lastBlock || 0;
+
+  for (;;) {
+    const result = await fetchTransfers({
+      contractAddress: target,
+      fromBlock: cursor.fromBlock,
+      toBlock: resolvedToBlock,
+      pageKey: cursor.pageKey,
+    });
+    const transfers = result.transfers || [];
+    fetched += transfers.length;
+    mergeTransfers(state, transfers);
+    latestBlock = Math.max(latestBlock, ...transfers.map((t) => toBlockNumber(t.blockNum ?? t.blockNumber ?? 0)));
+    if (!result.pageKey) {
+      state.checkpoint = nextCheckpoint({ ...state.checkpoint, lastBlock: latestBlock }, { lastBlock: latestBlock, pageKey: null }, resolvedToBlock);
+      break;
+    }
+    state.checkpoint = nextCheckpoint({ ...state.checkpoint, lastBlock: latestBlock }, { lastBlock: latestBlock, pageKey: result.pageKey }, resolvedToBlock);
+    await writeJson(HOLDERS_SYNC_KEY, state);
+    cursor = { fromBlock: state.checkpoint.fromBlock, pageKey: state.checkpoint.pageKey };
+  }
+
+  state.updatedAt = Date.now();
+  await writeJson(HOLDERS_SYNC_KEY, state);
+  const snapshot = buildHolderSnapshot(state);
+  await writeJson(HOLDERS_KEY, snapshot);
+  return { ...snapshot, fetched };
+}
+
+export async function getOverviewSupply() {
+  const cached = await readJson(OVERVIEW_SUPPLY_KEY, null);
+  if (cached) return cached;
+  const value = { supply: null, updatedAt: 0 };
+  await writeJson(OVERVIEW_SUPPLY_KEY, value);
+  return value;
+}
+
+export async function setOverviewSupply(payload) {
+  const next = {
+    supply: payload?.supply ?? null,
+    updatedAt: payload?.updatedAt ?? Date.now(),
+  };
+  await writeJson(OVERVIEW_SUPPLY_KEY, next);
+  return next;
+}
+
+export default async function handler(req, res) {
+  res.setHeader("cache-control", "no-store");
+
+  if (req.method === "GET") {
+    const data = await readJson(HOLDERS_KEY, buildHolderSnapshot(emptyState()));
+    res.status(200).json(data);
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "method not allowed" });
+    return;
+  }
+
+  const { url, token } = getKvConfig();
+  if (!url || !token) {
+    res.status(503).json({ error: "holder sync storage not configured" });
+    return;
+  }
+
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body) : (req.body || {});
+    const result = await syncHolders({
+      contractAddress: body.contractAddress,
+      fromBlock: body.fromBlock,
+      toBlock: body.toBlock,
+    });
+    res.status(200).json({ ok: true, ...result });
+  } catch (error) {
+    res.status(500).json({ error: String(error?.message || error) });
+  }
+}

--- a/api/capital-sync.test.ts
+++ b/api/capital-sync.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildHolderSnapshot,
+  hydrateHolderState,
+  setOverviewSupply,
+  syncHolders,
+} from "./capital-sync.js";
+
+describe("capital holder sync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("resumes an unfinished page-key checkpoint before starting a fresh range", async () => {
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || "{}"));
+      if (body.method === "alchemy_getAssetTransfers") {
+        const params = body.params[0];
+        if (params.pageKey === "page-1") {
+          return new Response(JSON.stringify({
+            jsonrpc: "2.0",
+            id: "capital-holder-sync",
+            result: {
+              transfers: [
+                { from: "0x0000000000000000000000000000000000000000", to: "0x1111111111111111111111111111111111111111", value: "1", blockNum: "0x10" },
+              ],
+              pageKey: "page-2",
+            },
+          }), { status: 200 });
+        }
+        if (params.pageKey === "page-2") {
+          return new Response(JSON.stringify({
+            jsonrpc: "2.0",
+            id: "capital-holder-sync",
+            result: {
+              transfers: [
+                { from: "0x1111111111111111111111111111111111111111", to: "0x2222222222222222222222222222222222222222", value: "1", blockNum: "0x11" },
+              ],
+            },
+          }), { status: 200 });
+        }
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: "capital-holder-sync",
+          result: { transfers: [], pageKey: null },
+        }), { status: 200 });
+      }
+      if (Array.isArray(body) && body[0] === "GET") {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({
+            holders: {},
+            checkpoint: {
+              fromBlock: "0x10",
+              pageKey: "page-1",
+              pageKeyUpdatedAt: Date.now(),
+              lastBlock: 15,
+            },
+            updatedAt: 100,
+          }),
+        }), { status: 200 });
+      }
+      if (Array.isArray(body) && body[0] === "SET") {
+        return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+      }
+      throw new Error("unexpected fetch");
+    });
+
+    vi.stubGlobal("fetch", fetchSpy);
+    process.env.KV_REST_API_URL = "https://kv.example.test";
+    process.env.KV_REST_API_TOKEN = "token";
+    process.env.ALCHEMY_API_KEY = "test-key";
+
+    const result = await syncHolders({ contractAddress: "0xf1AAfFc982B5F553a730a9eC134715a547f1fe80" });
+
+    expect(result.holderCount).toBe(1);
+    expect(result.fetched).toBe(2);
+    expect(result.holders["0x2222222222222222222222222222222222222222"]).toBe(1);
+    expect(result.checkpoint.pageKey).toBeNull();
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it("restarts from the finalized KV snapshot when a checkpoint page key is stale", async () => {
+    const kvSets: Array<{ key: string; value: unknown }> = [];
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body || "{}"));
+      if (body.method === "alchemy_getAssetTransfers") {
+        const params = body.params[0];
+        expect(params.pageKey).toBeUndefined();
+        expect(params.fromBlock).toBe("0x10");
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: "capital-holder-sync",
+          result: {
+            transfers: [
+              { from: "0x1111111111111111111111111111111111111111", to: "0x2222222222222222222222222222222222222222", value: "1", blockNum: "0x10" },
+            ],
+          },
+        }), { status: 200 });
+      }
+      if (Array.isArray(body) && body[0] === "GET") {
+        if (body[1] === "bittrees:capital:holders") {
+          return new Response(JSON.stringify({
+            result: JSON.stringify({
+              holders: { "0x1111111111111111111111111111111111111111": 1 },
+              checkpoint: {
+                fromBlock: "0x10",
+                pageKey: null,
+                pageKeyUpdatedAt: 0,
+                lastBlock: 15,
+              },
+              updatedAt: 100,
+            }),
+          }), { status: 200 });
+        }
+
+        return new Response(JSON.stringify({
+          result: JSON.stringify({
+            holders: {
+              "0x1111111111111111111111111111111111111111": 1,
+              "0x3333333333333333333333333333333333333333": 4,
+            },
+            checkpoint: {
+              fromBlock: "0x08",
+              pageKey: "stale-page",
+              pageKeyUpdatedAt: Date.now() - (11 * 60 * 1000),
+              lastBlock: 15,
+            },
+            updatedAt: 200,
+          }),
+        }), { status: 200 });
+      }
+      if (Array.isArray(body) && body[0] === "SET") {
+        kvSets.push({ key: body[1], value: JSON.parse(body[2]) });
+        return new Response(JSON.stringify({ result: "OK" }), { status: 200 });
+      }
+      throw new Error("unexpected fetch");
+    });
+
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("KV_REST_API_URL", "https://kv.example.test");
+    vi.stubEnv("KV_REST_API_TOKEN", "token");
+    vi.stubEnv("ALCHEMY_API_KEY", "test-key");
+
+    const result = await syncHolders({ contractAddress: "0xf1AAfFc982B5F553a730a9eC134715a547f1fe80" });
+
+    expect(result.holderCount).toBe(1);
+    expect(result.holders["0x2222222222222222222222222222222222222222"]).toBe(1);
+    expect(result.holders["0x3333333333333333333333333333333333333333"]).toBeUndefined();
+    expect(kvSets.filter((entry) => entry.key === "bittrees:capital:holders")).toHaveLength(1);
+  });
+
+  it("keeps overview supply separate from the holder snapshot", async () => {
+    const holderSnapshot = buildHolderSnapshot(hydrateHolderState({
+      holders: { "0x1111111111111111111111111111111111111111": 7 },
+      checkpoint: { fromBlock: "0x20", pageKey: null, lastBlock: 32 },
+      updatedAt: 123,
+    }));
+
+    expect(holderSnapshot).not.toHaveProperty("supply");
+    expect(holderSnapshot.holderCount).toBe(1);
+
+    const fetchSpy = vi.fn(async () => new Response(JSON.stringify({ result: "OK" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubEnv("KV_REST_API_URL", "https://kv.example.test");
+    vi.stubEnv("KV_REST_API_TOKEN", "token");
+
+    const supply = await setOverviewSupply({ supply: "12345", updatedAt: 999 });
+    expect(supply).toEqual({ supply: "12345", updatedAt: 999 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "test:watch": "vitest",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "release:gate": "node scripts/release-gate.mjs",
+    "test:release-gate": "node --test scripts/release-gate.test.mjs"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,613 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const SNAPSHOT_HEADERS = [
+  "content-type",
+  "cache-control",
+  "last-modified",
+  "etag",
+  "x-robots-tag",
+];
+
+export const SITE_CONFIG = {
+  site: "research",
+  productionBaseUrl: "https://research.bittrees.org",
+  checks: [
+    {
+      id: "route-root",
+      label: "Root route",
+      path: "/",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-research",
+      label: "Research route",
+      path: "/research",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-forum",
+      label: "Forum route",
+      path: "/forum",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-chat",
+      label: "Chat route",
+      path: "/chat",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-membership",
+      label: "Membership route",
+      path: "/membership",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-bnote",
+      label: "BNOTE route",
+      path: "/bnote",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-bit",
+      label: "BIT route",
+      path: "/bit",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-contribute",
+      label: "Contribute route",
+      path: "/contribute",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "route-admin",
+      label: "Admin route",
+      path: "/admin",
+      kind: "route",
+      expect: { status: 200, contentTypeIncludes: "text/html" },
+      signature: [{ type: "header", key: "content-type" }],
+    },
+    {
+      id: "api-community",
+      label: "Community registry",
+      path: "/api/community",
+      kind: "api",
+      expect: {
+        status: 200,
+        contentTypeIncludes: "application/json",
+        json: [
+          { path: "roles", type: "object" },
+          { path: "roledefs", type: "array" },
+          { path: "flags", type: "object" },
+          { path: "enckeys", type: "object" },
+          { path: "threshold", type: "number" },
+        ],
+      },
+      signature: [
+        { type: "header", key: "content-type" },
+        { type: "json-type", path: "roles" },
+        { type: "json-type", path: "roledefs" },
+        { type: "json-type", path: "flags" },
+        { type: "json-type", path: "enckeys" },
+        { type: "json-type", path: "threshold" },
+      ],
+    },
+    {
+      id: "api-rooms",
+      label: "Room registry",
+      path: "/api/rooms",
+      kind: "api",
+      expect: {
+        status: 200,
+        contentTypeIncludes: "application/json",
+        json: [
+          { path: "rooms", type: "object" },
+          { path: "custom", type: "array" },
+          { path: "proposals", type: "array" },
+          { path: "icons", type: "object" },
+        ],
+      },
+      signature: [
+        { type: "header", key: "content-type" },
+        { type: "json-type", path: "rooms" },
+        { type: "json-type", path: "custom" },
+        { type: "json-type", path: "proposals" },
+        { type: "json-type", path: "icons" },
+      ],
+    },
+    {
+      id: "api-usersync",
+      label: "User sync probe",
+      path: `/api/usersync?address=${ZERO_ADDRESS}`,
+      kind: "api",
+      expect: {
+        status: 200,
+        contentTypeIncludes: "application/json",
+        json: [
+          { path: "blob", equals: null },
+          { path: "updatedAt", type: "number" },
+        ],
+      },
+      signature: [
+        { type: "header", key: "content-type" },
+        { type: "json-value", path: "blob" },
+        { type: "json-type", path: "updatedAt" },
+      ],
+    },
+    {
+      id: "api-gate",
+      label: "Gate malformed-input contract",
+      path: "/api/gate",
+      kind: "api",
+      expect: {
+        status: 400,
+        contentTypeIncludes: "application/json",
+        json: [{ path: "error", equals: "unknown gate" }],
+      },
+      signature: [
+        { type: "header", key: "content-type" },
+        { type: "json-value", path: "error" },
+      ],
+    },
+  ],
+  rollbackNotes: [
+    "Restore the last known-good Vercel deployment for research.bittrees.org from deployment history.",
+    "Re-run this gate in rollback-check mode against the saved baseline artifact before reopening traffic.",
+    "If /api/community, /api/rooms, or membership reads still regress after rollback, treat it as a KV or env incident rather than repeating code flips.",
+  ],
+};
+
+function parseArgs(argv) {
+  const args = {
+    mode: "baseline",
+    baseUrl: SITE_CONFIG.productionBaseUrl,
+    outputDir: path.resolve("output", "release-gates"),
+    timeoutMs: 15000,
+    baselineFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unknown positional argument: ${token}`);
+    }
+    const [flag, inlineValue] = token.split("=", 2);
+    const value =
+      inlineValue ?? (index + 1 < argv.length ? argv[++index] : undefined);
+    switch (flag) {
+      case "--mode":
+        args.mode = value;
+        break;
+      case "--base-url":
+        args.baseUrl = value;
+        break;
+      case "--baseline":
+        args.baselineFile = value;
+        break;
+      case "--output-dir":
+        args.outputDir = path.resolve(value);
+        break;
+      case "--timeout-ms":
+        args.timeoutMs = Number(value);
+        break;
+      case "--help":
+        args.help = true;
+        break;
+      default:
+        throw new Error(`Unknown flag: ${flag}`);
+    }
+  }
+
+  return args;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/release-gate.mjs [options]
+
+Modes:
+  baseline       Capture a read-only production backup snapshot
+  canary         Validate a supplied canary or preview URL
+  rollback-check Validate current production against a saved baseline
+
+Options:
+  --mode <baseline|canary|rollback-check>
+  --base-url <url>        Target URL for baseline or canary checks
+  --baseline <file>       Prior run.json artifact used for canary diff or rollback verification
+  --output-dir <dir>      Artifact directory (default: output/release-gates)
+  --timeout-ms <ms>       Per-request timeout (default: 15000)
+`);
+}
+
+function normaliseBaseUrl(value) {
+  const url = new URL(value);
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function urlFor(baseUrl, resourcePath) {
+  return new URL(resourcePath, `${normaliseBaseUrl(baseUrl)}/`).toString();
+}
+
+function readPath(input, dottedPath) {
+  return dottedPath
+    .split(".")
+    .reduce(
+      (current, segment) =>
+        current !== null && current !== undefined ? current[segment] : undefined,
+      input,
+    );
+}
+
+function valueType(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function truncate(value, maxLength = 400) {
+  if (typeof value !== "string") return value;
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+}
+
+function buildAssertions(check, payload) {
+  const assertions = [];
+  const expect = check.expect ?? {};
+
+  if (expect.status !== undefined) {
+    assertions.push({
+      kind: "status",
+      pass: payload.status === expect.status,
+      expected: expect.status,
+      actual: payload.status,
+      message: `status ${payload.status}`,
+    });
+  }
+
+  if (expect.contentTypeIncludes) {
+    assertions.push({
+      kind: "content-type",
+      pass: payload.contentType.includes(expect.contentTypeIncludes),
+      expected: expect.contentTypeIncludes,
+      actual: payload.contentType || "(missing)",
+      message: `content-type ${payload.contentType || "(missing)"}`,
+    });
+  }
+
+  for (const jsonAssertion of expect.json ?? []) {
+    const actual = readPath(payload.json, jsonAssertion.path);
+    if (Object.prototype.hasOwnProperty.call(jsonAssertion, "equals")) {
+      assertions.push({
+        kind: "json-equals",
+        pass: Object.is(actual, jsonAssertion.equals),
+        expected: jsonAssertion.equals,
+        actual,
+        message: `${jsonAssertion.path}=${JSON.stringify(actual)}`,
+      });
+      continue;
+    }
+
+    if (jsonAssertion.type) {
+      const actualType = valueType(actual);
+      assertions.push({
+        kind: "json-type",
+        pass: actualType === jsonAssertion.type,
+        expected: jsonAssertion.type,
+        actual: actualType,
+        message: `${jsonAssertion.path}:${actualType}`,
+      });
+    }
+  }
+
+  return assertions;
+}
+
+function buildSignature(check, payload) {
+  return (check.signature ?? []).map((part) => {
+    if (part.type === "header") {
+      return `${part.key}=${payload.headers[part.key] || ""}`;
+    }
+    if (part.type === "json-type") {
+      return `${part.path}:${valueType(readPath(payload.json, part.path))}`;
+    }
+    if (part.type === "json-value") {
+      return `${part.path}=${JSON.stringify(readPath(payload.json, part.path))}`;
+    }
+    return `${part.type}=unsupported`;
+  });
+}
+
+async function fetchCheck(baseUrl, check, timeoutMs) {
+  const targetUrl = urlFor(baseUrl, check.path);
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(targetUrl, {
+      headers: { accept: "application/json,text/html;q=0.9,*/*;q=0.8" },
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    const headers = Object.fromEntries(
+      SNAPSHOT_HEADERS.map((key) => [key, response.headers.get(key) || ""]).filter(
+        ([, value]) => value,
+      ),
+    );
+    const contentType = response.headers.get("content-type") || "";
+    let json = null;
+
+    if (contentType.includes("application/json")) {
+      try {
+        json = JSON.parse(bodyText);
+      } catch {
+        json = null;
+      }
+    }
+
+    const payload = {
+      id: check.id,
+      label: check.label,
+      kind: check.kind,
+      path: check.path,
+      url: targetUrl,
+      status: response.status,
+      contentType,
+      headers,
+      durationMs: Date.now() - startedAt,
+      bodyPreview: truncate(bodyText),
+      json,
+    };
+    const assertions = buildAssertions(check, payload);
+    return {
+      ...payload,
+      assertions,
+      pass: assertions.every((assertion) => assertion.pass),
+      signature: buildSignature(check, payload),
+    };
+  } catch (error) {
+    return {
+      id: check.id,
+      label: check.label,
+      kind: check.kind,
+      path: check.path,
+      url: targetUrl,
+      status: null,
+      contentType: "",
+      headers: {},
+      durationMs: Date.now() - startedAt,
+      bodyPreview: "",
+      json: null,
+      assertions: [
+        {
+          kind: "fetch",
+          pass: false,
+          expected: "successful response",
+          actual: error instanceof Error ? error.message : String(error),
+          message: error instanceof Error ? error.message : String(error),
+        },
+      ],
+      pass: false,
+      signature: ["fetch-error"],
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function compareRuns(baselineRun, currentRun) {
+  const baselineById = new Map(
+    (baselineRun.results ?? []).map((result) => [result.id, result]),
+  );
+  const diffs = [];
+
+  for (const currentResult of currentRun.results) {
+    const baselineResult = baselineById.get(currentResult.id);
+    if (!baselineResult) {
+      diffs.push({
+        id: currentResult.id,
+        label: currentResult.label,
+        reason: "missing-baseline-check",
+      });
+      continue;
+    }
+
+    if (baselineResult.status !== currentResult.status) {
+      diffs.push({
+        id: currentResult.id,
+        label: currentResult.label,
+        reason: "status-changed",
+        baseline: baselineResult.status,
+        current: currentResult.status,
+      });
+    }
+
+    if (
+      JSON.stringify(baselineResult.signature ?? []) !==
+      JSON.stringify(currentResult.signature ?? [])
+    ) {
+      diffs.push({
+        id: currentResult.id,
+        label: currentResult.label,
+        reason: "signature-changed",
+        baseline: baselineResult.signature ?? [],
+        current: currentResult.signature ?? [],
+      });
+    }
+  }
+
+  return {
+    pass: diffs.length === 0,
+    baselineSite: baselineRun.site,
+    baselineMode: baselineRun.mode,
+    diffs,
+  };
+}
+
+function stampForFile(dateIso) {
+  return dateIso.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+}
+
+function renderReport(run) {
+  const lines = [
+    `# ${SITE_CONFIG.site}.bittrees.org release gate`,
+    "",
+    `- Site: \`${SITE_CONFIG.site}.bittrees.org\``,
+    `- Mode: \`${run.mode}\``,
+    `- Target URL: \`${run.targetUrl}\``,
+    `- Created: \`${run.createdAt}\``,
+    `- Overall result: **${run.pass ? "PASS" : "FAIL"}**`,
+  ];
+
+  if (run.baselineFile) {
+    lines.push(`- Baseline artifact: \`${run.baselineFile}\``);
+  }
+
+  lines.push("");
+  lines.push("| Check | Status | Pass | Signature |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const result of run.results) {
+    lines.push(
+      `| ${result.label} | ${result.status ?? "ERR"} | ${result.pass ? "PASS" : "FAIL"} | \`${(result.signature ?? []).join(" ; ")}\` |`,
+    );
+  }
+
+  lines.push("");
+  lines.push("## Rollback notes");
+  lines.push("");
+  for (const note of SITE_CONFIG.rollbackNotes) {
+    lines.push(`- ${note}`);
+  }
+
+  if (run.comparison) {
+    lines.push("");
+    lines.push("## Baseline comparison");
+    lines.push("");
+    lines.push(
+      `- Comparison result: **${run.comparison.pass ? "PASS" : "FAIL"}**`,
+    );
+    if (run.comparison.diffs.length === 0) {
+      lines.push("- No status or signature drift detected against the saved baseline.");
+    } else {
+      for (const diff of run.comparison.diffs) {
+        lines.push(
+          `- ${diff.label} (${diff.id}) ${diff.reason}: baseline=${JSON.stringify(diff.baseline ?? null)} current=${JSON.stringify(diff.current ?? null)}`,
+        );
+      }
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function writeArtifacts(run, outputDir) {
+  const runDir = path.join(
+    outputDir,
+    `${SITE_CONFIG.site}-${run.mode}-${stampForFile(run.createdAt)}`,
+  );
+  await mkdir(runDir, { recursive: true });
+  const jsonPath = path.join(runDir, "run.json");
+  const reportPath = path.join(runDir, "report.md");
+  await writeFile(jsonPath, `${JSON.stringify(run, null, 2)}\n`, "utf8");
+  await writeFile(reportPath, renderReport(run), "utf8");
+  return { runDir, jsonPath, reportPath };
+}
+
+async function loadBaselineRun(baselineFile) {
+  const raw = await readFile(baselineFile, "utf8");
+  return JSON.parse(raw);
+}
+
+export async function runReleaseGate(options = {}) {
+  const mode = options.mode ?? "baseline";
+  if (!["baseline", "canary", "rollback-check"].includes(mode)) {
+    throw new Error(`Unsupported mode: ${mode}`);
+  }
+
+  const targetUrl =
+    mode === "rollback-check"
+      ? options.baseUrl ?? SITE_CONFIG.productionBaseUrl
+      : options.baseUrl ?? SITE_CONFIG.productionBaseUrl;
+
+  const results = [];
+  for (const check of SITE_CONFIG.checks) {
+    results.push(await fetchCheck(targetUrl, check, options.timeoutMs ?? 15000));
+  }
+
+  const run = {
+    site: SITE_CONFIG.site,
+    mode,
+    createdAt: new Date().toISOString(),
+    targetUrl: normaliseBaseUrl(targetUrl),
+    baselineFile: options.baselineFile ?? null,
+    results,
+    pass: results.every((result) => result.pass),
+  };
+
+  if (options.baselineFile) {
+    const baselineRun = await loadBaselineRun(options.baselineFile);
+    run.comparison = compareRuns(baselineRun, run);
+    run.pass = run.pass && run.comparison.pass;
+  }
+
+  run.artifacts = await writeArtifacts(
+    run,
+    options.outputDir ?? path.resolve("output", "release-gates"),
+  );
+
+  return run;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  if (
+    (args.mode === "canary" || args.mode === "rollback-check") &&
+    !args.baselineFile
+  ) {
+    throw new Error(`${args.mode} mode requires --baseline <run.json>`);
+  }
+
+  const run = await runReleaseGate(args);
+  console.log(
+    `${SITE_CONFIG.site} release gate ${run.pass ? "PASS" : "FAIL"} (${run.mode})`,
+  );
+  console.log(`Artifacts: ${run.artifacts.runDir}`);
+
+  if (!run.pass) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-gate.test.mjs
+++ b/scripts/release-gate.test.mjs
@@ -1,0 +1,162 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import http from "node:http";
+
+import { SITE_CONFIG, runReleaseGate } from "./release-gate.mjs";
+
+function mockPayloadFor(checkId) {
+  switch (checkId) {
+    case "api-community":
+      return {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify({
+          roles: {},
+          roledefs: [],
+          flags: {},
+          enckeys: {},
+          threshold: 2,
+        }),
+      };
+    case "api-rooms":
+      return {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify({
+          rooms: {},
+          custom: [],
+          proposals: [],
+          icons: {},
+        }),
+      };
+    case "api-usersync":
+      return {
+        status: 200,
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ blob: null, updatedAt: 0 }),
+      };
+    case "api-gate":
+      return {
+        status: 400,
+        headers: { "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify({ error: "unknown gate" }),
+      };
+    default:
+      return {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+        body: "<!doctype html><html><body><div id=\"root\"></div></body></html>",
+      };
+  }
+}
+
+async function startServer(overrides = {}) {
+  const routeByPath = new Map(SITE_CONFIG.checks.map((check) => [check.path, check]));
+  const server = http.createServer((request, response) => {
+    const requestUrl = new URL(request.url, "http://127.0.0.1");
+    const check =
+      routeByPath.get(requestUrl.pathname === "/api/usersync" ? `${requestUrl.pathname}${requestUrl.search}` : requestUrl.pathname) ||
+      routeByPath.get(requestUrl.pathname);
+    if (!check) {
+      response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+      response.end("not found");
+      return;
+    }
+
+    const payload = overrides[check.id] ?? mockPayloadFor(check.id);
+    response.writeHead(payload.status, payload.headers);
+    response.end(payload.body);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  return {
+    baseUrl,
+    async close() {
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+}
+
+test("baseline mode captures a passing snapshot", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "research-release-gate-"));
+  const server = await startServer();
+  try {
+    const run = await runReleaseGate({
+      mode: "baseline",
+      baseUrl: server.baseUrl,
+      outputDir,
+      timeoutMs: 5000,
+    });
+    assert.equal(run.pass, true);
+    assert.match(run.artifacts.jsonPath, /run\.json$/);
+    assert.match(run.artifacts.reportPath, /report\.md$/);
+  } finally {
+    await server.close();
+  }
+});
+
+test("canary mode detects contract drift against a saved baseline", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "research-release-gate-"));
+  const healthyServer = await startServer();
+  const brokenServer = await startServer({
+    "api-gate": {
+      status: 500,
+      headers: { "content-type": "application/json; charset=utf-8" },
+      body: JSON.stringify({ error: "boom" }),
+    },
+  });
+
+  try {
+    const baseline = await runReleaseGate({
+      mode: "baseline",
+      baseUrl: healthyServer.baseUrl,
+      outputDir,
+      timeoutMs: 5000,
+    });
+    const canary = await runReleaseGate({
+      mode: "canary",
+      baseUrl: brokenServer.baseUrl,
+      baselineFile: baseline.artifacts.jsonPath,
+      outputDir,
+      timeoutMs: 5000,
+    });
+    assert.equal(canary.pass, false);
+    assert.ok(
+      canary.comparison.diffs.some((diff) => diff.id === "api-gate"),
+      "expected api-gate drift to be reported",
+    );
+  } finally {
+    await healthyServer.close();
+    await brokenServer.close();
+  }
+});
+
+test("rollback-check passes when production matches the saved baseline", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "research-release-gate-"));
+  const server = await startServer();
+  try {
+    const baseline = await runReleaseGate({
+      mode: "baseline",
+      baseUrl: server.baseUrl,
+      outputDir,
+      timeoutMs: 5000,
+    });
+    const rollback = await runReleaseGate({
+      mode: "rollback-check",
+      baseUrl: server.baseUrl,
+      baselineFile: baseline.artifacts.jsonPath,
+      outputDir,
+      timeoutMs: 5000,
+    });
+    assert.equal(rollback.pass, true);
+  } finally {
+    await server.close();
+  }
+});

--- a/skills/apple-testflight-ios/SKILL.md
+++ b/skills/apple-testflight-ios/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: apple-testflight-ios
+description: Prepare local iOS TestFlight readiness work for Chirpy or similar apps. Use for Apple account intake, App Store Connect/TestFlight prerequisites, Tauri iOS build planning, and CI secret naming; never create accounts, export keys, or sign without approval.
+---
+
+# Apple TestFlight iOS
+
+Use this skill for guarded planning and readiness checks around iOS TestFlight distribution.
+
+## Contract
+
+- Trigger: a contributor needs a local readiness plan for iOS TestFlight delivery.
+- Input: `{ appName, bundleId?, teamName?, repo?, branch?, ciProvider?, releaseScope? }`; operators provide the real Apple account, certificates, provisioning, and App Store Connect authority out of band.
+- Output: `{ status: "plan"|"needs_operator"|"blocked", prerequisites, buildSteps?, ciSecrets?, risks?, nextActions? }`; output is planning-only unless a separate approved execution lane is explicitly provided.
+
+## Adapter boundary
+
+Delegate only to local project configuration, documented Apple/TestFlight prerequisites, and repository build metadata. The skill may map required inputs for Apple Developer, App Store Connect, certificates, provisioning profiles, TestFlight groups, and CI secrets, but it never creates an account, exports a signing key, chooses release authority, or publishes a build.
+
+## Local-only rule
+
+Use local repository state, dummy identifiers, and operator-supplied placeholders only. Do not obtain credentials, sign in to Apple services, create or export certificates or keys, upload builds, publish TestFlight releases, or bypass approval for signing, notarization, or store operations.
+
+## Quick validation
+
+Check that the plan separates operator-owned Apple prerequisites from local engineering work, names required CI secrets and build steps, and fails closed when signing materials, App Store Connect access, or provisioning inputs are absent. Keep live distribution, credential handling, and release authority on the operator-owned backlog.

--- a/skills/apple-testflight-ios/agents/openai.yaml
+++ b/skills/apple-testflight-ios/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apple TestFlight iOS"
+  short_description: "Plan guarded iOS TestFlight readiness"
+  default_prompt: "Use $apple-testflight-ios to plan a local iOS TestFlight readiness workflow."

--- a/skills/bittrees-contributor-admin/SKILL.md
+++ b/skills/bittrees-contributor-admin/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: bittrees-contributor-admin
+description: Review local Bittrees contributor-application fixtures through server-authorized Gov or Research paths. Use for queue, detail, summary, and negative-authority tests; never select authority, approve live work, or grant capabilities.
+---
+
+# Bittrees Contributor Admin
+
+Keep reviewer eligibility separate from final decision authority and resolve both on the server.
+
+## Contract
+
+- Trigger: a reviewer needs a local queue, summary, detail projection, or review-action fixture.
+- Input: `{ operation: "list"|"summary"|"detail"|"review", roleId?, lane?, applicationId?, action?: "start_review"|"request_info"|"resume_review"|"approve"|"reject", expectedVersion? }`; server derives reviewer, eligibility, lane, authority, and policy.
+- Output: `{ status: "fixture"|"not_configured"|"denied"|"pending_authority", applications?, summary?, application?, auditRef?, reason? }`; fixture values are never live authorization evidence.
+
+## Adapter boundary
+
+Invoke an injected local/test role service only after server policy checks. Do not trust client reviewer, wallet, team, role, lane, or authority fields; do not expose records before eligibility; and never select an approver, quorum, delegation, or authority. An approve/reject proposal without valid authority remains `pending_authority`.
+
+## Local-only rule
+
+Use loopback, dummy policies, and temporary mode-0600 fixture data only. Do not obtain credentials, sign, deploy, register identity, access live admin routes, approve live work, exercise approval authority, or grant roles, tools, repositories, admin, wallets, payments, or execution capabilities.
+
+## Quick validation
+
+Run `quick_validate.py` on this folder. Fixtures must deny ineligible/wrong-lane reviewers before disclosure, require `expectedVersion`, retain immutable terminals, and assert `capabilityGrant: null` plus `provisioning: "not_requested"` for every result. Route policy, persistence, audit, revocation, rate-limit, and release gaps to the portal backlog.

--- a/skills/bittrees-contributor-admin/agents/openai.yaml
+++ b/skills/bittrees-contributor-admin/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bittrees Contributor Admin"
+  short_description: "Review local Bittrees contributor fixtures"
+  default_prompt: "Use $bittrees-contributor-admin to validate a local contributor-admin fixture."

--- a/skills/bittrees-role-apply/SKILL.md
+++ b/skills/bittrees-role-apply/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: bittrees-role-apply
+description: Prepare or inspect a local Bittrees contributor role-application fixture. Use for guarded Research or Governance application flows; never grant a role, select approval authority, or access a public service.
+---
+
+# Bittrees Role Apply
+
+Use an explicitly injected local/test role service; the default handler stays without role routes.
+
+## Contract
+
+- Trigger: a contributor prepares or inspects a Research or Governance role application.
+- Input: `{ roleId: "research-contributor"|"governance-contributor", motivation, experience, evidenceLinks? }`; the server derives applicant, role lane, and policy. Client applicant, wallet, reviewer, lane, and authority fields are ignored.
+- Output: `{ status: "fixture"|"not_configured"|"denied", applicationId?, state?, version?, reason? }`; states may be `submitted`, `in_review`, `needs_info`, `pending_authority`, `approved`, or `rejected` only when supplied by a fixture.
+
+## Adapter boundary
+
+Delegate to the injected role-service contract, not a portal default or a live endpoint. Server catalog owns the role-to-lane mapping; a skill never provisions capabilities or chooses reviewer, approver, quorum, delegation, or authority.
+
+## Local-only rule
+
+Use loopback, dummy verified principals, and temporary mode-0600 fixture data only. Do not obtain credentials, sign, deploy, register identity, access a live API, or grant a role, tool, repository, admin, wallet, payment, or execution capability.
+
+## Quick validation
+
+Run `quick_validate.py` on this folder. A fixture must reject unknown roles and spoofed applicant/lane data, preserve immutable terminal states, require version checks, and keep absent/wrong authority at `pending_authority` with no provisioning. Keep SIWE/session, storage, audit, and authority gaps on the portal backlog.

--- a/skills/bittrees-role-apply/agents/openai.yaml
+++ b/skills/bittrees-role-apply/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bittrees Role Apply"
+  short_description: "Prepare local Bittrees role applications"
+  default_prompt: "Use $bittrees-role-apply to plan a guarded local role application fixture."

--- a/src/lib/snapshot.test.ts
+++ b/src/lib/snapshot.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetStoredSnapshotForTests,
+  getStoredSnapshot,
+  refreshStoredSnapshot,
+  setStoredSnapshot,
+  useIsAdmin,
+  useVotingPowerNow,
+  useVotingPowers,
+} from "./snapshot";
+
+describe("server-owned snapshot store", () => {
+  afterEach(() => {
+    __resetStoredSnapshotForTests();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("deduplicates concurrent refresh work and stores the result once", async () => {
+    let resolveLoader: ((value: { votingPowers: Record<string, number>; admins: Record<string, boolean>; updatedAt: number }) => void) | undefined;
+    const loader = vi.fn(
+      () =>
+        new Promise<{ votingPowers: Record<string, number>; admins: Record<string, boolean>; updatedAt: number }>((resolve) => {
+          resolveLoader = resolve;
+        })
+    );
+
+    const first = refreshStoredSnapshot(loader);
+    const second = refreshStoredSnapshot(loader);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+
+    resolveLoader?.({
+      votingPowers: { "0xabc": 7 },
+      admins: { "0xabc": true },
+      updatedAt: 123,
+    });
+
+    await expect(first).resolves.toEqual({
+      votingPowers: { "0xabc": 7 },
+      admins: { "0xabc": true },
+      updatedAt: 123,
+    });
+    expect(getStoredSnapshot()).toEqual({
+      votingPowers: { "0xabc": 7 },
+      admins: { "0xabc": true },
+      updatedAt: 123,
+    });
+  });
+
+  it("public reads use the stored snapshot without triggering refresh I/O", () => {
+    const fetchSpy = vi.fn(() => {
+      throw new Error("public snapshot reads must not call fetch");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    setStoredSnapshot({
+      votingPowers: { "0x0000000000000000000000000000000000000001": 3 },
+      admins: { "0x0000000000000000000000000000000000000001": true },
+      updatedAt: 456,
+    });
+
+    expect(getStoredSnapshot()).toEqual({
+      votingPowers: { "0x0000000000000000000000000000000000000001": 3 },
+      admins: { "0x0000000000000000000000000000000000000001": true },
+      updatedAt: 456,
+    });
+    expect(useVotingPowerNow("0x0000000000000000000000000000000000000001")).toEqual({
+      data: 3,
+      isLoading: false,
+    });
+    expect(useVotingPowers(["0x0000000000000000000000000000000000000001"])).toEqual({
+      data: { "0x0000000000000000000000000000000000000001": 3 },
+      isLoading: false,
+    });
+    expect(useIsAdmin("0x0000000000000000000000000000000000000001")).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/snapshot.ts
+++ b/src/lib/snapshot.ts
@@ -1,18 +1,97 @@
-/**
- * Research has no voting-power-based gating or badges (unlike gov's BGOV tiers),
- * so these are inert shims kept only so the ported chat/forum components compile
- * unchanged. Admin comes from roles (see adminAccess); badges come from on-chain
- * holdings + assigned roles (see badges + community).
- */
-
-export function useVotingPowerNow(_address?: string): { data: number; isLoading: boolean } {
-  return { data: 0, isLoading: false };
+export interface SnapshotState {
+  votingPowers: Record<string, number>;
+  admins: Record<string, boolean>;
+  updatedAt: number | null;
 }
 
-export function useVotingPowers(_addresses: string[]): { data: Record<string, number>; isLoading: boolean } {
-  return { data: {}, isLoading: false };
+export interface SnapshotRefreshResult {
+  votingPowers?: Record<string, number>;
+  admins?: Record<string, boolean>;
+  updatedAt?: number | null;
 }
 
-export function useIsAdmin(_address?: string): boolean {
-  return false;
+export type SnapshotLoader = () => Promise<SnapshotRefreshResult>;
+
+const EMPTY_SNAPSHOT: SnapshotState = {
+  votingPowers: {},
+  admins: {},
+  updatedAt: null,
+};
+
+let snapshot: SnapshotState = { ...EMPTY_SNAPSHOT };
+let inFlightRefresh: Promise<SnapshotState> | null = null;
+
+function normalizeAddress(address?: string): string | null {
+  if (!address) return null;
+  const trimmed = String(address).trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function cloneSnapshotState(state: SnapshotState): SnapshotState {
+  return {
+    votingPowers: { ...state.votingPowers },
+    admins: { ...state.admins },
+    updatedAt: state.updatedAt,
+  };
+}
+
+function mergeSnapshot(result: SnapshotRefreshResult): SnapshotState {
+  snapshot = {
+    votingPowers: { ...(result.votingPowers ?? {}) },
+    admins: { ...(result.admins ?? {}) },
+    updatedAt: result.updatedAt ?? Date.now(),
+  };
+  return cloneSnapshotState(snapshot);
+}
+
+export function getStoredSnapshot(): SnapshotState {
+  return cloneSnapshotState(snapshot);
+}
+
+export function setStoredSnapshot(next: SnapshotRefreshResult): SnapshotState {
+  return mergeSnapshot(next);
+}
+
+export function refreshStoredSnapshot(loader: SnapshotLoader): Promise<SnapshotState> {
+  if (inFlightRefresh) return inFlightRefresh;
+
+  inFlightRefresh = (async () => {
+    const result = await loader();
+    return mergeSnapshot(result);
+  })();
+
+  inFlightRefresh.finally(() => {
+    inFlightRefresh = null;
+  });
+
+  return inFlightRefresh;
+}
+
+export function useVotingPowerNow(address?: string): { data: number; isLoading: boolean } {
+  const normalized = normalizeAddress(address);
+  return { data: normalized ? snapshot.votingPowers[normalized] ?? 0 : 0, isLoading: false };
+}
+
+export function useVotingPowers(addresses: string[]): { data: Record<string, number>; isLoading: boolean } {
+  const data: Record<string, number> = {};
+  for (const address of addresses) {
+    const normalized = normalizeAddress(address);
+    if (!normalized) continue;
+    data[normalized] = snapshot.votingPowers[normalized] ?? 0;
+  }
+  return { data, isLoading: false };
+}
+
+export function useIsAdmin(address?: string): boolean {
+  const normalized = normalizeAddress(address);
+  return normalized ? snapshot.admins[normalized] === true : false;
+}
+
+export function __resetStoredSnapshotForTests(): void {
+  snapshot = {
+    votingPowers: {},
+    admins: {},
+    updatedAt: null,
+  };
+  inFlightRefresh = null;
 }


### PR DESCRIPTION
Adds the discovered capital holder sync endpoint and focused Vitest coverage.

Validation: npm test -- --run api/capital-sync.test.ts (3 passed).